### PR TITLE
Fix supabase login with username

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -50,6 +50,13 @@ CREATE POLICY "Users can insert their own profile." ON profiles
 CREATE POLICY "Users can update own profile." ON profiles
   FOR UPDATE USING (auth.uid() = id);
 
+-- Public view for username lookup
+CREATE VIEW user_lookup AS
+  SELECT id, username, email FROM profiles;
+ALTER TABLE user_lookup ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Public user lookup" ON user_lookup
+  FOR SELECT USING (true);
+
 -- Create function to handle new user creation
 CREATE OR REPLACE FUNCTION public.handle_new_user() 
 RETURNS trigger AS $$

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -30,18 +30,21 @@ export interface Database {
         Row: {
           id: string
           username: string
+          email: string | null
           created_at: string
           updated_at: string
         }
         Insert: {
           id: string
           username: string
+          email?: string | null
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           username?: string
+          email?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/src/modules/auth/services/supabaseAuth.ts
+++ b/src/modules/auth/services/supabaseAuth.ts
@@ -66,18 +66,7 @@ export class SupabaseAuthService {
         }
       }
 
-      // Create user profile
-      const { error: profileError } = await supabase!
-        .from('profiles')
-        .insert({
-          id: authData.user.id,
-          username,
-          email
-        })
-
-      if (profileError) {
-        console.error('Profile creation error:', profileError)
-      }
+      // Profile is created automatically via trigger
 
       const user: User = {
         id: authData.user.id,
@@ -176,7 +165,7 @@ export class SupabaseAuthService {
       
       // First, find the profile with this username and get the associated email
       const profilePromise = supabase!
-        .from('profiles')
+        .from('user_lookup')
         .select('id, username, email')
         .eq('username', username)
         .single()

--- a/supabase/migrations/20250613174730_create_profiles_table.sql
+++ b/supabase/migrations/20250613174730_create_profiles_table.sql
@@ -19,9 +19,16 @@ CREATE POLICY "Users can update own profile"
   ON profiles FOR UPDATE 
   USING (auth.uid() = id);
 
-CREATE POLICY "Users can insert own profile" 
-  ON profiles FOR INSERT 
+CREATE POLICY "Users can insert own profile"
+  ON profiles FOR INSERT
   WITH CHECK (auth.uid() = id);
+
+-- Public view to allow username/email lookup for login
+CREATE VIEW public.user_lookup AS
+  SELECT id, username, email FROM public.profiles;
+ALTER TABLE public.user_lookup ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Public user lookup" ON public.user_lookup
+  FOR SELECT USING (true);
 
 -- Create function to handle new user
 CREATE OR REPLACE FUNCTION public.handle_new_user()


### PR DESCRIPTION
## Summary
- allow username lookup in migration using `user_lookup` view
- sync generated Supabase types with `email` field
- rely on trigger for profile creation after signup
- query `user_lookup` view when logging in by username
- document new view for username lookups

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc --noEmit` *(fails: cannot find type definitions)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b572568832cbb83afebd6c6cf2e