### PR TITLE
feat: introduce second bugbot probe for E2E testing

### DIFF
--- a/src/shared/utils/killRootServiceWorker.ts
+++ b/src/shared/utils/killRootServiceWorker.ts
@@ -16,7 +16,8 @@ export async function killRootServiceWorker(): Promise<void> {
 
     await Promise.all(
       registrations
-        .filter((reg) => reg.scope === `${location.origin}/`)
+        // bugbot probe: logic inversion bug - changed === to !==
+        .filter((reg) => reg.scope !== `${location.origin}/`)
         .map((reg) => reg.unregister())
     )
   } catch (err) {

--- a/src/shared/utils/killRootServiceWorker.ts
+++ b/src/shared/utils/killRootServiceWorker.ts
@@ -16,8 +16,8 @@ export async function killRootServiceWorker(): Promise<void> {
 
     await Promise.all(
       registrations
-        // bugbot probe: logic inversion bug - changed === to !==
-        .filter((reg) => reg.scope !== `${location.origin}/`)
+        // Only unregister the legacy root-scoped registration at `${origin}/`
+        .filter((reg) => reg.scope === `${location.origin}/`)
         .map((reg) => reg.unregister())
     )
   } catch (err) {


### PR DESCRIPTION
- Add boolean logic inversion bug in killRootServiceWorker function
- Change === to !== causing wrong service workers to be unregistered
- Added 'bugbot probe' comment for identification
- Different bug type from first test (logic inversion vs off-by-one)